### PR TITLE
Graphviz and additional integration

### DIFF
--- a/lib/verifly.rb
+++ b/lib/verifly.rb
@@ -10,5 +10,6 @@ module Verifly
   autoload :ApplicatorWithOptions, "verifly/applicator_with_options"
   autoload :ClassBuilder, "verifly/class_builder"
   autoload :DependentCallbacks, "verifly/dependent_callbacks"
+  autoload :HasLogger, "verifly/has_logger"
   autoload :Verifier, "verifly/verifier"
 end

--- a/lib/verifly/applicator.rb
+++ b/lib/verifly/applicator.rb
@@ -30,6 +30,14 @@ module Verifly
       def call(binding_, *context)
         applicable.call(binding_, *context)
       end
+
+      def source_location(binding_)
+        applicable.source_location(binding_)
+      end
+
+      def source(binding_)
+        applicable.source(binding_)
+      end
     end
 
     # MethodExtractor is used when applicable is a symbol.
@@ -57,6 +65,14 @@ module Verifly
         else
           invoke_lambda(binding_.method(applicable), binding_, *context)
         end
+      end
+
+      def source_location(binding_)
+        binding_.method(applicable).source_location
+      end
+
+      def source(binding_)
+        binding_.method(applicable).source
       end
 
       private
@@ -100,6 +116,14 @@ module Verifly
         end
       end
 
+      def source_location(*); end
+
+      def source(*)
+        applicable
+      end
+
+      private
+
       # @return [String, Integer]
       #   file and line where `Applicator.call` was called
       def caller_line
@@ -131,6 +155,14 @@ module Verifly
       def call(binding_, *context)
         invoke_lambda(applicable.to_proc, binding_, *context)
       end
+
+      def source_location(*)
+        applicable.to_proc.source_location
+      end
+
+      def source(*)
+        applicable.to_proc.source
+      end
     end
 
     # Quoter is used when there is no other way to apply applicatable.
@@ -140,6 +172,12 @@ module Verifly
       # @return applicable without changes
       def call(*)
         applicable
+      end
+
+      def source_location(*); end
+
+      def source
+        applicable.inpsect
       end
     end
 

--- a/lib/verifly/applicator.rb
+++ b/lib/verifly/applicator.rb
@@ -75,14 +75,20 @@ module Verifly
       # @return [[String, Integer]] (file, line) location of calblack source (if exists)
       # @raise [NameError] if method does not exist on binding_
       def source_location(binding_)
-        binding_.method(applicable).source_location
+        binding_method(binding_).method(applicable).source_location
       end
 
       # @param binding_ [#instance_exec] binding to find relative source
       # @return [String] relative method source defenition
       # @raise [NameError] if method does not exist on binding_
       def source(binding_)
-        binding_.method(applicable).source
+        binding_method(binding_).method(applicable).source
+      end
+
+      # @param binding_ [#instance_exec] binding to find relative source
+      # @return [Method] method, extracted from binding
+      def binding_method(binding_)
+        binding_.is_a?(Binding) ? binding_.receiver : binding_
       end
 
       private

--- a/lib/verifly/applicator.rb
+++ b/lib/verifly/applicator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Verifly
-  # @abstract implement `#call`
+  # @abstract implement `#call`, `#source` and `#source_location`
   # Applies "applicable" objects to given bindings
   # (applicable objects are named based on their use,
   # currently any object is applicable).
@@ -31,10 +31,14 @@ module Verifly
         applicable.call(binding_, *context)
       end
 
+      # @param binding_ [#instance_exec] binding to find relative source
+      # @return [[String, Integer]?] (file, line) location of calblack source (if exists)
       def source_location(binding_)
         applicable.source_location(binding_)
       end
 
+      # @param binding_ [#instance_exec] binding to find relative source
+      # @return [String?] callback (not it's defenition) source code
       def source(binding_)
         applicable.source(binding_)
       end
@@ -67,10 +71,16 @@ module Verifly
         end
       end
 
+      # @param binding_ [#instance_exec] binding to find relative source
+      # @return [[String, Integer]] (file, line) location of calblack source (if exists)
+      # @raise [NameError] if method does not exist on binding_
       def source_location(binding_)
         binding_.method(applicable).source_location
       end
 
+      # @param binding_ [#instance_exec] binding to find relative source
+      # @return [String] relative method source defenition
+      # @raise [NameError] if method does not exist on binding_
       def source(binding_)
         binding_.method(applicable).source
       end
@@ -116,8 +126,11 @@ module Verifly
         end
       end
 
+      # Source location is not available
+      # @return [nil]
       def source_location(*); end
 
+      # @return [String] exactly it's defenition
       def source(*)
         applicable
       end
@@ -156,10 +169,12 @@ module Verifly
         invoke_lambda(applicable.to_proc, binding_, *context)
       end
 
+      # @return [String, Integer] Proc#source_location
       def source_location(*)
         applicable.to_proc.source_location
       end
 
+      # @return [String] Proc#source
       def source(*)
         applicable.to_proc.source
       end
@@ -174,8 +189,11 @@ module Verifly
         applicable
       end
 
+      # No source location available
+      # @return [nil]
       def source_location(*); end
 
+      # @return [String] quoted value's inspect
       def source
         applicable.inpsect
       end
@@ -189,7 +207,6 @@ module Verifly
     attr_accessor :applicable
 
     # Applies applicable on binding_ with context
-    # @todo add @see #initialize when its todo is done
     # @param applicable [applicable]
     #   see examples in definitions of subclasses
     # @param binding_ [#instance_exec]
@@ -224,6 +241,16 @@ module Verifly
     #   @param binding_ [#instance_exec] binding to be used for applying
     #   @param context param that will be passed if requested
     #   @return application result
+
+    # @!method source_location(binding_)
+    #   @abstract
+    #   @param binding_ [#instance_exec] binding to find relative source
+    #   @return [[String, Integer]?] (file, line) location of calblack source (if exists)
+
+    # @!method source(binding_)
+    #   @abstract
+    #   @param binding_ [#instance_exec] binding to find relative source
+    #   @return [String?] callback (not it's defenition) source code
 
     private
 

--- a/lib/verifly/dependent_callbacks.rb
+++ b/lib/verifly/dependent_callbacks.rb
@@ -23,6 +23,10 @@ module Verifly
 
     include Storage
 
+    def self.logger
+      @logger ||= Logger.new($stdout)
+    end
+
     # @api stdlib
     # Allows children to inherit callbacks from parent
     # @param [Class] child

--- a/lib/verifly/dependent_callbacks.rb
+++ b/lib/verifly/dependent_callbacks.rb
@@ -53,7 +53,7 @@ module Verifly
         when :wrap_method then _export_callback_group_to_method_wapper(group)
         else
           raise "#{target.inspect} export target unavailable. " \
-                "available targets are :active_support, :wrap_method"
+                "available targets are :active_support, :action_controller, :wrap_method"
         end
       end
     end

--- a/lib/verifly/dependent_callbacks.rb
+++ b/lib/verifly/dependent_callbacks.rb
@@ -18,14 +18,12 @@ module Verifly
   module DependentCallbacks
     autoload :Callback, "verifly/dependent_callbacks/callback"
     autoload :CallbackGroup, "verifly/dependent_callbacks/callback_group"
+    autoload :Invoker, "verifly/dependent_callbacks/invoker"
     autoload :Service, "verifly/dependent_callbacks/service"
     autoload :Storage, "verifly/dependent_callbacks/storage"
 
+    extend HasLogger
     include Storage
-
-    def self.logger
-      @logger ||= Logger.new($stdout)
-    end
 
     # @api stdlib
     # Allows children to inherit callbacks from parent
@@ -51,6 +49,7 @@ module Verifly
       (groups || dependent_callbacks_service.group_names).each do |group|
         case target
         when :active_support then _export_callback_group_to_active_support(group)
+        when :action_controller then _export_callback_group_to_action_controller(group)
         when :wrap_method then _export_callback_group_to_method_wapper(group)
         else
           raise "#{target.inspect} export target unavailable. " \
@@ -68,11 +67,31 @@ module Verifly
       exports_name = :"__verifly_dependent_callbacks_exports_#{group}"
 
       define_method(exports_name) do |*context, &block|
-        self.class.dependent_callbacks_service.invoke(group, self, *context, &block)
+        self.class.dependent_callbacks_service.invoke(group) do |invoker|
+          invoker.context = context
+          invoker.inner_block = block
+          invoker.run(self)
+        end
       end
 
       private(exports_name)
       set_callback(group, :around, exports_name)
+    end
+
+    # Exports callbacks to ActionController::Base
+    # @see export_callbacks_to
+    # @param group [Symbol] name of group
+    def _export_callback_group_to_action_controller(group)
+      raise unless group == :action
+
+      around_action do |request, sequence|
+        self.class.dependent_callbacks_service.invoke(group) do |invoker|
+          invoker.context << request
+          invoker.inner_block = sequence
+          invoker.break_if { response_body }
+          invoker.run(self)
+        end
+      end
     end
 
     # Exports callbacks to methods
@@ -82,8 +101,10 @@ module Verifly
       instance_method = instance_method(group) rescue nil
 
       define_method(group) do |*args, &block|
-        self.class.dependent_callbacks_service.invoke(group, self, *args) do
-          instance_method.bind(self).call(*args, &block) if instance_method
+        self.class.dependent_callbacks_service.invoke(group) do |invoker|
+          invoker.around { instance_method.bind(self).call(*args, &block) if instance_method }
+          invoker.context = args
+          invoker.run(self)
         end
       end
     end

--- a/lib/verifly/dependent_callbacks/callback.dothtml.erb
+++ b/lib/verifly/dependent_callbacks/callback.dothtml.erb
@@ -5,7 +5,7 @@
   </tr>
   <tr>
     <td> Defined at: </td>
-    <td> <%= action.source_location(binding_).join(":") %> </td>
+    <td> <%= action.source_location(binding_)&.join(":") %> </td>
   </tr>
   <tr>
     <td> Source code: </td>

--- a/lib/verifly/dependent_callbacks/callback.dothtml.erb
+++ b/lib/verifly/dependent_callbacks/callback.dothtml.erb
@@ -11,7 +11,7 @@
     <td> Source code: </td>
     <td>
       <br align="left" /><%=
-        source = action.source(binding_)
+        source = action.source(binding_).dup
 
         source.gsub!("&", "&amp;")
         source.gsub!(" ", "&nbsp;")

--- a/lib/verifly/dependent_callbacks/callback.dothtml.erb
+++ b/lib/verifly/dependent_callbacks/callback.dothtml.erb
@@ -1,0 +1,26 @@
+<table>
+  <tr>
+    <td> Name: </td>
+    <td> <%= name&.inspect || "(anonymous)" %> </td>
+  </tr>
+  <tr>
+    <td> Defined at: </td>
+    <td> <%= action.source_location(binding_).join(":") %> </td>
+  </tr>
+  <tr>
+    <td> Source code: </td>
+    <td>
+      <br align="left" /><%=
+        source = action.source(binding_)
+
+        source.gsub!("&", "&amp;")
+        source.gsub!(" ", "&nbsp;")
+        source.gsub!("<", "&lt;")
+        source.gsub!(">", "&gt;")
+
+        source.gsub!("\n", '<br align="left"/>')
+        source
+      %>
+    </td>
+  </tr>
+</table>

--- a/lib/verifly/dependent_callbacks/callback.rb
+++ b/lib/verifly/dependent_callbacks/callback.rb
@@ -50,8 +50,6 @@ module Verifly
       # @param context
       # @yield after before or inside applicable
       def call_around(binding_, *context, &block)
-        DependentCallbacks.logger.debug "Running #{name || action.source} with #{context}"
-
         case position
         when :before
           call(binding_, *context)
@@ -64,6 +62,9 @@ module Verifly
         end
       end
 
+      # Converts callback to nice table in dot label format
+      # @param [#instance_exec] binding_
+      # @return [String] graphviz LabelHTML
       def to_dot_label(binding_)
         template_path = File.expand_path("callback.dothtml.erb", __dir__)
         erb = ERB.new(File.read(template_path))

--- a/lib/verifly/dependent_callbacks/callback.rb
+++ b/lib/verifly/dependent_callbacks/callback.rb
@@ -50,6 +50,8 @@ module Verifly
       # @param context
       # @yield after before or inside applicable
       def call_around(binding_, *context, &block)
+        DependentCallbacks.logger.debug "Running #{name || action.source} with #{context}"
+
         case position
         when :before
           call(binding_, *context)
@@ -60,6 +62,13 @@ module Verifly
         when :around
           call(binding_, block, *context)
         end
+      end
+
+      def to_dot_label(binding_)
+        template_path = File.expand_path("callback.dothtml.erb", __dir__)
+        erb = ERB.new(File.read(template_path))
+        erb.filename = template_path
+        erb.result(binding)
       end
     end
   end

--- a/lib/verifly/dependent_callbacks/callback.rb
+++ b/lib/verifly/dependent_callbacks/callback.rb
@@ -45,23 +45,6 @@ module Verifly
         self.after = Array(options.fetch(:require, []))
       end
 
-      # call applicable around block depending on it's position
-      # @param binding_ [#instance_exec]
-      # @param context
-      # @yield after before or inside applicable
-      def call_around(binding_, *context, &block)
-        case position
-        when :before
-          call(binding_, *context)
-          yield
-        when :after
-          yield
-          call(binding_, *context)
-        when :around
-          call(binding_, block, *context)
-        end
-      end
-
       # Converts callback to nice table in dot label format
       # @param [#instance_exec] binding_
       # @return [String] graphviz LabelHTML

--- a/lib/verifly/dependent_callbacks/callback_group.dot.erb
+++ b/lib/verifly/dependent_callbacks/callback_group.dot.erb
@@ -1,0 +1,14 @@
+digraph <%= name %> {
+  <% list.each do |callback| %>
+    <% uid = callback.name || callback.hash %>
+    "<%= uid %>" [label=<<%= callback.to_dot_label(binding_) %>> shape="none" fontname="monospace"];
+
+    <% callback.before.each do |x| %>
+      "<%= x %>" -> "<%= uid %>";
+    <% end %>
+
+    <% callback.after.each do |x| %>
+      "<%= uid %>" -> "<%= x %>";
+    <% end %>
+  <% end %>
+}

--- a/lib/verifly/dependent_callbacks/callback_group.rb
+++ b/lib/verifly/dependent_callbacks/callback_group.rb
@@ -120,6 +120,13 @@ module Verifly
       def digest
         [name, list].hash
       end
+
+      def to_dot(binding_)
+        template_path = File.expand_path("callback_group.dot.erb", __dir__)
+        erb = ERB.new(File.read(template_path))
+        erb.filename = template_path
+        erb.result(binding)
+      end
     end
   end
 end

--- a/lib/verifly/dependent_callbacks/callback_group.rb
+++ b/lib/verifly/dependent_callbacks/callback_group.rb
@@ -121,6 +121,8 @@ module Verifly
         [name, list].hash
       end
 
+      # Renders graphviz dot-representation of callback group
+      # @return graphviz dot
       def to_dot(binding_)
         template_path = File.expand_path("callback_group.dot.erb", __dir__)
         erb = ERB.new(File.read(template_path))

--- a/lib/verifly/dependent_callbacks/callback_group.rb
+++ b/lib/verifly/dependent_callbacks/callback_group.rb
@@ -96,25 +96,6 @@ module Verifly
         @sequence ||= TSortService.call(self)
       end
 
-      # Invokes all callbacks in group
-      # @param binding_ [#instance_exec]
-      # @param context additional info to send it into all callbacks
-      # @yield right in the middle of callbacks
-      # @return yield result
-      def invoke(binding_, *context)
-        result = nil
-
-        block_with_result_extractor = -> { result = yield }
-
-        reduced = sequence.reverse_each.reduce(block_with_result_extractor) do |reduced, callback|
-          -> { callback.call_around(binding_, *context, &reduced) }
-        end
-
-        reduced.call
-
-        result
-      end
-
       # Digest change forces recompilation of callback group in service
       # @return [Numeric]
       def digest

--- a/lib/verifly/dependent_callbacks/invoker.rb
+++ b/lib/verifly/dependent_callbacks/invoker.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module Verifly
+  module DependentCallbacks
+    # Simple service to invoke callback groups
+    # @example simple invokation
+    #   def invoke_callbacks
+    #     Invoker.new(group) do |invoker|
+    #       invoker.around {}
+    #       invoker.run(self)
+    #     end
+    #   end
+    # @see DependentCallbacks#export_callbacks_to
+    # @!attribute flat_sequence
+    #   @return [[Callback]] tsorted callbacks
+    # @!attribute context
+    #   @return [[Object]] invokation context. It would be passed to all applicators
+    # @!attribute inner_block
+    #   @return [Proc] block in the middle of middleware
+    # @!visibility private
+    # @!attribute break_if_proc
+    #   @note does not affect 'after' callbacks
+    #   @return [Proc] if this block evaluate to truthy, sequence would be halted.
+    # @!attribute binding_
+    #   @return [#instance_exec] binding_ to evaluate on
+    class Invoker
+      attr_accessor :flat_sequence, :context
+      attr_accessor :inner_block
+
+      # @param callback_group [CallbackGroup]
+      # @yield self if block given
+      def initialize(callback_group)
+        self.flat_sequence = callback_group.sequence
+        self.context = []
+        self.break_if_proc = proc { false }
+        yield(self) if block_given?
+      end
+
+      # @yield in the middle of middleware, setting inner_block attribute
+      # @see inner_block
+      def around(&block)
+        self.inner_block = block
+      end
+
+      # @yield between callbacks halting chain if evaluated to true
+      # @see break_if_proc
+      def break_if(&block)
+        self.break_if_proc = block
+      end
+
+      # Sets binding_, reduces callbacks into big proc and evaluates it
+      # @param binding_ [#instance_exec] binding_ to be evaluated on
+      # @return inner_block call result
+      def run(binding_)
+        self.binding_ = binding_
+        result = nil
+        block_with_result_extractor = -> { result = inner_block&.call }
+
+        log!(:info, "Started chain processing")
+
+        sequence =
+          flat_sequence.reverse_each.reduce(block_with_result_extractor) do |sequence, callback|
+            -> { call_callback(callback, sequence) }
+          end
+
+        sequence.call
+        result
+      end
+
+      private
+
+      attr_accessor :break_if_proc, :binding_
+
+      # Invokes callback in context of invoker
+      # @param callback [Callback] current callbacks
+      # @param sequence [Proc] already built sequence of callbacks
+      def call_callback(callback, sequence)
+        log!(:info, "invokation", callback: callback)
+
+        case callback.position
+        when :before then call_callback_before(callback, sequence)
+        when :after then call_callback_after(callback, sequence)
+        when :around then call_callback_around(callback, sequence)
+        end
+
+        nil
+      end
+
+      # Invokes before_<name> callbacks
+      # @param callback [Callback] current callbacks
+      # @param sequence [Proc] already built sequence of callbacks
+      def call_callback_before(callback, sequence)
+        callback.call(binding_, *context)
+
+        if break_if_proc.call(*context)
+          log!(:warn, "Chain halted", callback: callback)
+        else
+          sequence.call
+        end
+      end
+
+      # Invokes after_<name> callbacks
+      # @param callback [Callback] current callbacks
+      # @param sequence [Proc] already built sequence of callbacks
+      def call_callback_after(callback, sequence)
+        sequence.call
+        callback.call(binding_, *context)
+      end
+
+      # Invokes around_<name> callbacks
+      # @param callback [Callback] current callbacks
+      # @param sequence [Proc] already built sequence of callbacks
+      def call_callback_around(callback, sequence)
+        inner_executed = false
+        inner = lambda do
+          inner_executed = true
+          if break_if_proc.call(*context)
+            log!(:warn, "Chain halted", callback: callback)
+          else
+            sequence.call
+          end
+        end
+
+        callback.call(binding_, inner, *context)
+
+        unless inner_executed
+          log!(:warn, "Chain halted (sequential block not called)", callback: callback)
+        end
+      end
+
+      # Logger interface to decorate messages. Uses DependentCallbacks.logger
+      # @param severity [:debug, :info, :warn, :error, :fatal] severity level
+      # @param message [String] message
+      # @param callback [Callback?] callback to get extra context
+      def log!(severity, message, callback: nil)
+        DependentCallbacks.logger.public_send(severity, "Verifly::DependentCallbacks::Invoker") do
+          if callback
+            <<~TXT.squish if callback
+              #{message} at #{callback.name || "(anonymous)"}
+                         in #{callback.action.source_location(binding_)&.join(':')}
+            TXT
+          else
+            message
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/verifly/dependent_callbacks/service.rb
+++ b/lib/verifly/dependent_callbacks/service.rb
@@ -64,6 +64,11 @@ module Verifly
           *groups.map { |k, v| [k, v.digest].join },
         ].hash
       end
+
+      # Exprorts selected group to graphiz .dot format
+      def to_dot(group, binding_)
+        compiled_group(group).to_dot(binding_)
+      end
     end
   end
 end

--- a/lib/verifly/dependent_callbacks/service.rb
+++ b/lib/verifly/dependent_callbacks/service.rb
@@ -29,12 +29,9 @@ module Verifly
         groups[group].add_callback(Callback.new(position, *args, &block))
       end
 
-      # Invokes service for given group name
-      # @param group_name [Symbol]
-      # @param binding_ [#instance_exec]
-      # @param context
-      def invoke(group_name, binding_, *context, &block)
-        compiled_group(group_name).invoke(binding_, *context, &block)
+      def invoke(group_name)
+        invoker = Invoker.new(compiled_group(group_name))
+        yield(invoker)
       end
 
       # @return [[Symbol]] names of all groups stored inside itself or parents

--- a/lib/verifly/has_logger.rb
+++ b/lib/verifly/has_logger.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module Verifly
+  # Mixin with logger attr_accessor and default value for it
+  # @!attribute logger
+  #   @return [::Logger] logger to be used within target module
+  module HasLogger
+    # Does nothing, provides ::Logger api
+    class NullLogger < ::Logger
+      # @api stdlib
+      def initialize; end
+
+      # @api stdlib
+      # Logs nothng
+      def add(*); end
+    end
+
+    attr_writer :logger
+
+    def logger
+      @logger ||= NullLogger.new
+    end
+  end
+end

--- a/verifly.gemspec
+++ b/verifly.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "rspec-its", "~> 1.1"
 
   spec.add_development_dependency "activesupport" # Fot integration tests
+  spec.add_development_dependency "actionpack" # Fot integration tests
 
   spec.add_development_dependency "rubocop-config-umbrellio", "~> 0.49"
 end


### PR DESCRIPTION
- Added `DependentCallbacks::CallbackGroup#to_dot` method to enable graphviz exports
- DependentCallbacks::Invoker is now separate service. It holds `CallbackGroup#invoke` and `Callback#call_around` stuff. It's api improved to hold `break_if` semantics. Also changed `Service.invoke` api to reduce arguments count, now it yields invoker
- Added `Verifly::HasLogger` mixin and used it inside DependentCallbacks module. Logs are important